### PR TITLE
Supply old/previous value for cc changes

### DIFF
--- a/MidiInAndGuiMonitor.ahk
+++ b/MidiInAndGuiMonitor.ahk
@@ -12,8 +12,10 @@
 
 MidiMsgDetect(hInput, midiMsg, wMsg) ; Midi input section in "under the hood" calls this function each time a midi message is received. Then the midi message is broken up into parts for manipulation.  See http://www.midi.org/techspecs/midimessages.php (decimal values).
   {
-    global statusbyte, chan, note, cc, byte1, byte2, stb
+    global statusbyte, chan, note, cc, byte1, byte2, stb, oldbyte2
     
+	oldbyte2	:= byte2
+	
     statusbyte 	:=  midiMsg & 0xFF			; EXTRACT THE STATUS BYTE (WHAT KIND OF MIDI MESSAGE IS IT?)
     chan 		:= (statusbyte & 0x0f) + 1	; WHAT MIDI CHANNEL IS THE MESSAGE ON?
     byte1 		:= (midiMsg >> 8) & 0xFF	; THIS IS DATA1 VALUE = NOTE NUMBER OR CC NUMBER
@@ -101,7 +103,7 @@ MidiRules:
         isNoteOn := (statusbyte >= 144 and byte2 > 0)
         ProcessNote(0, chan, byte1, byte2, isNoteOn)
     } else if (statusbyte >= 176 and statusbyte <= 191) { ; CC
-        ProcessCC(0, chan, byte1, byte2)
+        ProcessCC(0, chan, byte1, byte2, oldbyte2)
     } else if (statusbyte >= 192 and statusbyte <= 208) { ; PC
         ProcessPC(0, chan, byte1, byte2)
     } else if (statusbyte >= 224 and statusbyte <= 239) { ; Pitch bend

--- a/MidiRules.ahk
+++ b/MidiRules.ahk
@@ -12,7 +12,7 @@ ProcessNote(device, channel, note, velocity, isNoteOn) {
 
 }
 
-ProcessCC(device, channel, cc, value) {
+ProcessCC(device, channel, cc, value, oldvalue) {
     if (cc = 21 or cc = 29) {
         scaled_value := ConvertCCValueToScale(value, 0, 127)
         vol := scaled_value * 100


### PR DESCRIPTION
Added old/previous value for cc changes so it is also possible to apply this in situations where you cannot or do not want to set an absolute value, but only slide/offset something.